### PR TITLE
Add support for structured logging

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -28,6 +28,7 @@ See an example file [here](default.json).
 * `authentication.jwt.validateAudience` e.g. "^hearth:example-app\\d+$" - a regular expression to match when validating the audience of a JWT token.
 * `authentication.jwt.expiresIn` e.g. "1d" - the expiry time to set when signing a JWT token.
 * `logger.level` e.g. "info" - the winston logger level, see [here](https://github.com/winstonjs/winston#logging-levels)
+* `logger.format` e.g. "json" to enable structured logging in JSON format. Valid options: `text` or `json`.
 * `idGenerator` e.g. "uuidv4" - which uuid algorithm to use to generate unique identifier for resoruces. See [here](https://github.com/kelektiv/node-uuid). We recommend using uuidv4 as it produces random IDs which would be difficult to guess without knowing the actual ID.
 * `atnaAudit.enabled` e.g. true - enables sending of ATNA audits for PIXm and PDQm IHE profiles.
 * `atnaAudit.interface` e.g. "udp" - interface to send audits on. Valid options: `udp`, `tls` or `tcp`.

--- a/config/default.json
+++ b/config/default.json
@@ -23,7 +23,8 @@
     }
   },
   "logger": {
-    "level": "info"
+    "level": "info",
+    "format": "text"
   },
   "idGenerator": "uuidv4",
   "atnaAudit": {

--- a/lib/custom-api/session.js
+++ b/lib/custom-api/session.js
@@ -12,7 +12,7 @@ const passwordHelper = require('./password-helper')
 
 const fs = require('fs')
 const jwt = require('jsonwebtoken')
-const logger = require('winston')
+const logger = require('../logger')
 
 function isSessionCreationEnabled () {
   return config.getConf('authentication:type') === 'jwt'

--- a/lib/custom-api/user.js
+++ b/lib/custom-api/user.js
@@ -7,7 +7,7 @@
  */
 
 'use strict'
-const logger = require('winston')
+const logger = require('../logger')
 const passwordHelper = require('./password-helper')
 
 const FhirCommon = require('../fhir/common')

--- a/lib/fhir/core.js
+++ b/lib/fhir/core.js
@@ -7,7 +7,7 @@
  */
 'use strict'
 
-const logger = require('winston')
+const logger = require('../logger')
 
 const FhirCommon = require('./common')
 const Authorization = require('../security/authorization')

--- a/lib/fhir/module-loader.js
+++ b/lib/fhir/module-loader.js
@@ -10,7 +10,7 @@
 
 const fs = require('fs')
 const path = require('path')
-const logger = require('winston')
+const logger = require('../logger')
 
 const fhirResources = {}
 

--- a/lib/fhir/resources/binary.js
+++ b/lib/fhir/resources/binary.js
@@ -9,7 +9,7 @@
 'use strict'
 
 const mongodb = require('mongodb')
-const logger = require('winston')
+const logger = require('../../logger')
 
 const FhirCommon = require('../common')
 const FhirRoot = require('../root')

--- a/lib/fhir/resources/patient.js
+++ b/lib/fhir/resources/patient.js
@@ -7,7 +7,7 @@
  */
 
 'use strict'
-const logger = require('winston')
+const logger = require('../../logger')
 
 const config = require('../../config')
 const FhirCommon = require('../common')

--- a/lib/fhir/resources/practitioner.js
+++ b/lib/fhir/resources/practitioner.js
@@ -8,7 +8,7 @@
 
 'use strict'
 
-const logger = require('winston')
+const logger = require('../../logger')
 
 const FhirCommon = require('../common')
 const QueryUtils = require('../query-utils')

--- a/lib/fhir/root.js
+++ b/lib/fhir/root.js
@@ -10,7 +10,7 @@
 
 const async = require('async')
 const url = require('url')
-const logger = require('winston')
+const logger = require('../logger')
 
 const FhirCommon = require('./common')
 const FhirCore = require('./core')

--- a/lib/fhir/services/matching-worker/matching-worker.js
+++ b/lib/fhir/services/matching-worker/matching-worker.js
@@ -8,7 +8,7 @@
 'use strict'
 
 const cp = require('child_process')
-const logger = require('winston')
+const logger = require('../../../logger')
 
 module.exports = (mongo) => {
   const startMatchingWorker = (context) => {

--- a/lib/fhir/services/terminology-service.js
+++ b/lib/fhir/services/terminology-service.js
@@ -7,7 +7,7 @@
  */
 
 'use strict'
-const logger = require('winston')
+const logger = require('../../logger')
 const FhirCommon = require('../common')
 
 module.exports = (mongo) => {

--- a/lib/init.js
+++ b/lib/init.js
@@ -10,14 +10,3 @@
 
 const path = require('path')
 global.appRoot = path.join(path.resolve(__dirname), '..')
-
-// Load configuration
-const config = require('./config')
-
-const logger = require('winston')
-logger.remove(logger.transports.Console)
-logger.add(logger.transports.Console, {
-  colorize: true,
-  timestamp: true,
-  level: config.getConf('logger:level')
-})

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,21 @@
+const config = require('./config')
+const winston = require('winston')
+
+const logger = winston.createLogger({
+  level: config.getConf('logger:level'),
+  format:
+    // Maintain the format from Winston 2.x.
+    winston.format.combine(
+      winston.format.colorize(),
+      winston.format.errors({ stack: true }),
+      winston.format.timestamp(),
+      winston.format.printf((info) => {
+        return `${info.timestamp} - ${info.level}: ${
+          info.stack == null ? info.message : info.stack
+        }`
+      })
+    ),
+  transports: [new winston.transports.Console()]
+})
+
+module.exports = exports = logger

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,20 +1,31 @@
 const config = require('./config')
 const winston = require('winston')
 
+/**
+ * The JSON structured logging format.
+ */
+const JSON_FORMAT = 'json'
+
 const logger = winston.createLogger({
   level: config.getConf('logger:level'),
   format:
-    // Maintain the format from Winston 2.x.
-    winston.format.combine(
-      winston.format.colorize(),
-      winston.format.errors({ stack: true }),
-      winston.format.timestamp(),
-      winston.format.printf((info) => {
-        return `${info.timestamp} - ${info.level}: ${
-          info.stack == null ? info.message : info.stack
-        }`
-      })
-    ),
+    config.getConf('logger:format') === JSON_FORMAT
+      ? winston.format.combine(
+          winston.format.errors({ stack: true }),
+          winston.format.timestamp(),
+          winston.format.json()
+        )
+      // Maintain the format from Winston 2.x.
+      : winston.format.combine(
+          winston.format.colorize(),
+          winston.format.errors({ stack: true }),
+          winston.format.timestamp(),
+          winston.format.printf((info) => {
+            return `${info.timestamp} - ${info.level}: ${
+              info.stack == null ? info.message : info.stack
+            }`
+          })
+        ),
   transports: [new winston.transports.Console()]
 })
 

--- a/lib/matching-queue/matching-queue.js
+++ b/lib/matching-queue/matching-queue.js
@@ -9,7 +9,7 @@
 'use strict'
 
 const cp = require('child_process')
-const logger = require('winston')
+const logger = require('../logger')
 
 module.exports = (mongo) => {
   const startWorker = (workers, workerName) => {

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -9,7 +9,7 @@
 'use strict'
 const MongoClient = require('mongodb').MongoClient
 const config = require('./config')
-const logger = require('winston')
+const logger = require('./logger')
 
 const collapseWhenSingleClause = (query) => {
   const collapseOperatorsList = ['$and', '$or']

--- a/lib/plugins/audit.js
+++ b/lib/plugins/audit.js
@@ -8,7 +8,7 @@
 
 'use strict'
 
-const logger = require('winston')
+const logger = require('../logger')
 const moment = require('moment')
 
 const EVENT_OUTCOME = {

--- a/lib/plugins/default.js
+++ b/lib/plugins/default.js
@@ -8,7 +8,7 @@
 
 'use strict'
 
-const logger = require('winston')
+const logger = require('../logger')
 
 module.exports = () => {
   return {

--- a/lib/plugins/matching-queue.js
+++ b/lib/plugins/matching-queue.js
@@ -9,7 +9,7 @@
 'use strict'
 
 const mongoDbQueue = require('mongodb-queue')
-const logger = require('winston')
+const logger = require('../logger')
 
 const matchingConfig = require('../../config/matching')
 const constants = require('../constants')

--- a/lib/resource-linking.js
+++ b/lib/resource-linking.js
@@ -7,7 +7,7 @@
  */
 'use strict'
 
-const logger = require('winston')
+const logger = require('./logger')
 
 const FhirCommon = require('./fhir/common')
 const constants = require('./constants')

--- a/lib/security/authorization.js
+++ b/lib/security/authorization.js
@@ -7,7 +7,7 @@
  */
 
 'use strict'
-const logger = require('winston')
+const logger = require('../logger')
 const FhirCommon = require('../fhir/common')
 
 const userTypeRestrictions = {}

--- a/lib/security/jwt-authentication/index.js
+++ b/lib/security/jwt-authentication/index.js
@@ -11,7 +11,7 @@ const config = require('../../config')
 
 const fs = require('fs')
 const jwt = require('jsonwebtoken')
-const logger = require('winston')
+const logger = require('../../logger')
 
 const TOKEN_PATTERN = /^ *(?:[Bb][Ee][Aa][Rr][Ee][Rr]) +([A-Za-z0-9\-._~+/]+=*) *$/
 

--- a/lib/security/openhim-style-authentication.js
+++ b/lib/security/openhim-style-authentication.js
@@ -7,7 +7,7 @@
  */
 
 'use strict'
-const logger = require('winston')
+const logger = require('../logger')
 const config = require('../config')
 const crypto = require('crypto')
 const FhirCommon = require('../fhir/common')

--- a/lib/server.js
+++ b/lib/server.js
@@ -9,7 +9,7 @@
 'use strict'
 require('./init')
 
-const logger = require('winston')
+const logger = require('./logger')
 const express = require('express')
 const bodyParser = require('body-parser')
 const xmlParser = require('express-xml-bodyparser')

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "talisman": "^0.21.0",
     "urijs": "^1.19.2",
     "uuid": "^3.3.3",
-    "winston": "^2.4.2"
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "chalk": "^2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,15 @@
 # yarn lockfile v1
 
 
+"@dabh/diagnostics@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.2.tgz#290d08f7b381b8f94607dc8f471a12c675f9db31"
+  integrity sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==
+  dependencies:
+    colorspace "1.1.x"
+    enabled "2.0.x"
+    kuler "^2.0.0"
+
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.4.0.tgz#7b3ec2d96af481d7a0321252e7b1c94724ec5a78"
@@ -257,10 +266,10 @@ async@^2.6.1:
   dependencies:
     lodash "^4.17.14"
 
-async@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.0.0.tgz#f8fc04ca3a13784ade9e1641af98578cfbd647a9"
-  integrity sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=
+async@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.1.tgz#d3274ec66d107a47476a4c49136aacdb00665fc8"
+  integrity sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -655,7 +664,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -667,14 +676,43 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
+color-name@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.5.2:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.6.0.tgz#c3915f61fe267672cb7e1e064c9d692219f6c312"
+  integrity sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
 color-support@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
 
-colors@1.0.x:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
-  integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
+color@3.0.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.0.0.tgz#d920b4328d534a3ac8295d68f7bd4ba6c427be9a"
+  integrity sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==
+  dependencies:
+    color-convert "^1.9.1"
+    color-string "^1.5.2"
+
+colors@^1.2.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
+colorspace@1.1.x:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.2.tgz#e0128950d082b86a2168580796a0aa5d6c68d8c5"
+  integrity sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==
+  dependencies:
+    color "3.0.x"
+    text-hex "1.0.x"
 
 combined-stream@^1.0.5:
   version "1.0.6"
@@ -823,11 +861,6 @@ cryptiles@2.x.x:
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
   dependencies:
     boom "2.x.x"
-
-cycle@1.0.x:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
-  integrity sha1-IegLK+hYD5i0aPN5QwZisEbDStI=
 
 d@1:
   version "1.0.1"
@@ -1012,6 +1045,11 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+
+enabled@2.0.x:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
+  integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -1376,11 +1414,6 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-eyes@0.1.x:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
-  integrity sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=
-
 faker@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/faker/-/faker-4.1.0.tgz#1e45bbbecc6774b3c195fad2835109c6d748cc3f"
@@ -1398,6 +1431,16 @@ fast-json-stable-stringify@^2.0.0:
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
+fast-safe-stringify@^2.0.4:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz#dc2af48c46cf712b683e849b2bbd446b32de936f"
+  integrity sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag==
+
+fecha@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.1.tgz#0a83ad8f86ef62a091e22bb5a039cd03d23eecce"
+  integrity sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==
 
 fhir@^3.3.1:
   version "3.3.1"
@@ -1498,6 +1541,11 @@ flat-cache@^1.2.1:
     del "^2.0.2"
     graceful-fs "^4.1.2"
     write "^0.2.1"
+
+fn.name@1.x.x:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
+  integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -1956,6 +2004,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
 
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -2131,6 +2184,11 @@ is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
+is-stream@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
+  integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
@@ -2172,7 +2230,7 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-isstream@0.1.x, isstream@~0.1.2:
+isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
@@ -2376,6 +2434,11 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
+kuler@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
+  integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
+
 lcid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
@@ -2496,6 +2559,17 @@ log-driver@1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
   integrity sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=
+
+logform@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.2.0.tgz#40f036d19161fc76b68ab50fdc7fe495544492f2"
+  integrity sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==
+  dependencies:
+    colors "^1.2.1"
+    fast-safe-stringify "^2.0.4"
+    fecha "^4.2.0"
+    ms "^2.1.1"
+    triple-beam "^1.3.0"
 
 lolex@^4.1.0, lolex@^4.2.0:
   version "4.2.0"
@@ -3009,6 +3083,13 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
+one-time@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/one-time/-/one-time-1.0.0.tgz#e06bc174aed214ed58edede573b433bbf827cb45"
+  integrity sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==
+  dependencies:
+    fn.name "1.x.x"
+
 onetime@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
@@ -3405,10 +3486,32 @@ readable-stream@^2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-str
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readable-stream@^2.3.7:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
 readable-stream@^3.0.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
   integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
+readable-stream@^3.4.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -3723,6 +3826,13 @@ shelljs@^0.7.5:
 signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
+  dependencies:
+    is-arrayish "^0.3.1"
 
 sinon@^7.5.0:
   version "7.5.0"
@@ -4180,6 +4290,11 @@ test-exclude@^4.2.0:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
+text-hex@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
+  integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
+
 text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -4251,6 +4366,11 @@ treeify@^1.1.0:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+triple-beam@^1.2.0, triple-beam@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
+  integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
 trivial-deferred@^1.0.1:
   version "1.0.1"
@@ -4458,17 +4578,28 @@ window-size@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
 
-winston@^2.4.2:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-2.4.4.tgz#a01e4d1d0a103cf4eada6fc1f886b3110d71c34b"
-  integrity sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==
+winston-transport@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.4.0.tgz#17af518daa690d5b2ecccaa7acf7b20ca7925e59"
+  integrity sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==
   dependencies:
-    async "~1.0.0"
-    colors "1.0.x"
-    cycle "1.0.x"
-    eyes "0.1.x"
-    isstream "0.1.x"
+    readable-stream "^2.3.7"
+    triple-beam "^1.2.0"
+
+winston@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.3.3.tgz#ae6172042cafb29786afa3d09c8ff833ab7c9170"
+  integrity sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==
+  dependencies:
+    "@dabh/diagnostics" "^2.0.2"
+    async "^3.1.0"
+    is-stream "^2.0.0"
+    logform "^2.2.0"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
     stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.4.0"
 
 wordwrap@~0.0.2:
   version "0.0.3"


### PR DESCRIPTION
This depends on #1 so I've used that as the base for now, and we can change it to master once that PR has been merged. I'm leaving this in draft state until that's been done.

___

Add a config option which supports a value of `json` in order to enable
structured logging using the JSON format. This can be done by setting
the `logger.format` option in the environment specific configuration
file, or by specifying the `logger__format` environment variable.

An example log line will look like:

```json
{"message":"[development] Hearth FHIR server running on 0.0.0.0:3447","level":"info","timestamp":"2021-08-23T08:03:46.293Z"}
```

This allows for easier filtering of logs when using tools which support
line-delimited JSON such as `jq` or Amazon CloudWatch.