### PR TITLE
Apply selective dependency resolution for libxmljs

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,5 +71,8 @@
   "license": "MPL-2.0",
   "engines": {
     "node": ">= 6.9.0 <9.0.0"
+  },
+  "resolutions": {
+    "libxmljs": "0.19.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -412,10 +412,6 @@ bind-obj-methods@^1.0.0:
   resolved "https://registry.yarnpkg.com/bind-obj-methods/-/bind-obj-methods-1.0.0.tgz#4f5979cac15793adf70e488161e463e209ca509c"
   integrity sha1-T1l5ysFXk633DkiBYeRj4gnKUJw=
 
-bindings@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.2.1.tgz#14ad6113812d2d37d72e67b4cacb4bb726505f11"
-
 bindings@~1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
@@ -2457,14 +2453,7 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-libxmljs@0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/libxmljs/-/libxmljs-0.18.0.tgz#e2993dcf28e4dc60e73486e2db6225dc24d18531"
-  dependencies:
-    bindings "1.2.1"
-    nan "2.3.2"
-
-libxmljs@^0.19.7:
+libxmljs@0.18.0, libxmljs@0.19.7, libxmljs@^0.19.7:
   version "0.19.7"
   resolved "https://registry.yarnpkg.com/libxmljs/-/libxmljs-0.19.7.tgz#96c2151b0b73f33dd29917edec82902587004e5a"
   integrity sha512-lFJyG9T1mVwTzNTw6ZkvIt0O+NsIR+FTE+RcC2QDFGU8YMnQrnyEOGrj6HWSe1AdwQK7s37BOp4NL+pcAqfK2g==
@@ -2825,10 +2814,6 @@ mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
   integrity sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=
-
-nan@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.3.2.tgz#4d4ecf17e1da4e989efb4f273d8d00201cad087e"
 
 nan@~2.14.0:
   version "2.14.0"


### PR DESCRIPTION
This fixes the build on more recent versions of Node.js by making sure
that a newer version of the `nan` package is used. More testing needs to
be done to determine the level of compatibility with newer Node.js
versions before the engines field is updated.