### PR TITLE
Report errors encountered during startup to Sentry

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -362,6 +362,7 @@ if (!module.parent) {
     user.loadDefaultSysadmin((err) => {
       if (err) {
         logger.error(err)
+        Sentry.captureException(err)
       }
 
       // interrupt signal, e.g. ctrl-c


### PR DESCRIPTION
Errors coming from MongoDB were not being reported to Sentry during startup.