### PR TITLE
Add curl to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM node:14.17.6-alpine3.14 as build
-RUN apk update && apk add --no-cache build-base python3 py3-pip
+RUN apk add --no-cache build-base python3 py3-pip
 WORKDIR /app
 COPY package.json yarn.lock /app/
 RUN yarn install --frozen-lockfile --production && cd node_modules/libxmljs && yarn install
 
 FROM node:14.17.6-alpine3.14
 WORKDIR /app
+RUN apk add --no-cache curl
 COPY --from=build /app/node_modules /app/node_modules/
 COPY package.json yarn.lock /app/
 COPY config /app/config/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,8 @@ services:
       mongodb__url: "mongodb://mongo-db/hearth"
     ports:
       - "3447:3447"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3447/api/heartbeat"]
+      timeout: 5s
+      interval: 10s
+      retries: 3


### PR DESCRIPTION
It's used to perform health checks for the container by calling the API
heartbeat endpoint.